### PR TITLE
fix for datashift_spree:load:attach_images

### DIFF
--- a/lib/loaders/spree/image_loader.rb
+++ b/lib/loaders/spree/image_loader.rb
@@ -3,7 +3,8 @@
 # Date ::     Jan 2011
 # License::   MIT. Free, Open Source.
 #
-require 'loader_base'
+require 'spree_base_loader'
+require 'spree_helper'
 
 module DataShift
 


### PR DESCRIPTION
uninitialized constant DataShift::SpreeHelper::SpreeBaseLoader (NameError)
