### PR TITLE
Added method to load variant images and 'variant_cost_price' method

### DIFF
--- a/lib/loaders/spree/product_loader.rb
+++ b/lib/loaders/spree/product_loader.rb
@@ -142,8 +142,6 @@ module DataShift
           end          
           
         elsif(current_method_detail.operator?('variant_sku') && current_value)
-          puts "variant_sku: #{current_value.inspect}"
-          logger.debug "variant_sku: #{current_value.inspect}"
 
           if(@load_object.variants.size > 0)
 
@@ -522,7 +520,11 @@ module DataShift
   
             logger.info "Setting #{images.count} images for variant #{variants[i].name}..."
 
+            # reset variant images to attach to variant
+            var_images = []
+
             # Image processing...
+            logger.debug "Images to process: #{images.inspect} for variant #{variants[i].name}"
             images.each do |image|
               @spree_uri_regexp ||= Regexp::new('(http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:\/~\+#]*[\w\-\@?^=%&amp;\/~\+#])?' )
               
@@ -600,11 +602,11 @@ module DataShift
                 
                 path = File.join(config[:image_path_prefix], path) if(config[:image_path_prefix])
       
-                # create_attachment(klass, attachment_path, record = nil, attach_to_record_field = nil, options = {})
                 attachment = create_attachment(Spree::Image, path, nil, nil, :alt => alt_text)
 
               end 
 
+              logger.debug "#{attachment.inspect}"
               var_images << attachment if attachment
 
             end # images loop

--- a/lib/loaders/spree/product_loader.rb
+++ b/lib/loaders/spree/product_loader.rb
@@ -515,6 +515,7 @@ module DataShift
               images = variant_images.to_s.split(Delimiters::multi_value_delim)
             else
               # single image
+              images = []
               images << variant_images 
             end
   

--- a/lib/loaders/spree/product_loader.rb
+++ b/lib/loaders/spree/product_loader.rb
@@ -42,8 +42,8 @@ module DataShift
 
         # In >= 1.1.0 Image moved to master Variant from Product so no association called Images on Product anymore
         
-        # Non Product/database fields we can still  process
-        @we_can_process_these_anyway =  ['images',  "variant_price", "variant_cost_price", "variant_sku", "stock_items"]
+        # Non Product/database fields we can still process
+        @we_can_process_these_anyway =  ["images","variant_sku","variant_cost_price","variant_price","variant_images","stock_items"]
           
         # In >= 1.3.0 price moved to master Variant from Product so no association called Price on Product anymore
         # taking care of it here, means users can still simply just include a price column
@@ -95,7 +95,7 @@ module DataShift
           add_images( load_object.master )
         
         # This loads images to Product Variants
-        elsif(current_method_detail.operator?('variants_images') && current_value)
+        elsif(current_method_detail.operator?('variant_images') && current_value)
 
           add_variant_images(current_value)
 
@@ -142,6 +142,8 @@ module DataShift
           end          
           
         elsif(current_method_detail.operator?('variant_sku') && current_value)
+          puts "variant_sku: #{current_value.inspect}"
+          logger.debug "variant_sku: #{current_value.inspect}"
 
           if(@load_object.variants.size > 0)
 
@@ -502,9 +504,11 @@ module DataShift
           end
 
           variants = @load_object.variants # just for readability and logic
+
           logger.info "Variants: #{@load_object.variants.inspect}"
 
-          variants_images_list = get_each_assoc # we expect to get corresponding images for every variant (might have more than one image for each variant!)
+          # we expect to get corresponding images for every variant (might have more than one image for each variant!)
+          variants_images_list = get_each_assoc 
 
           variants_images_list.each_with_index do |variant_images, i|
 
@@ -519,7 +523,7 @@ module DataShift
             logger.info "Setting #{images.count} images for variant #{variants[i].name}..."
 
             # Image processing...
-            images.each do |îmage|
+            images.each do |image|
               @spree_uri_regexp ||= Regexp::new('(http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:\/~\+#]*[\w\-\@?^=%&amp;\/~\+#])?' )
               
               if(image.match(@spree_uri_regexp))
@@ -590,7 +594,7 @@ module DataShift
                 
                 path, alt_text = image.split(Delimiters::name_value_delim)
 
-                alt_text = path if !alt_text #ensure name is filled
+                alt_text = variants[i].name if !alt_text #ensure alt_text is filled
       
                 logger.debug("Processing IMAGE from PATH #{path.inspect} #{alt_text.inspect}")
                 
@@ -600,47 +604,135 @@ module DataShift
                 attachment = create_attachment(Spree::Image, path, nil, nil, :alt => alt_text)
 
               end 
-      
-              begin
-                owner.images << attachment
-                          
-                logger.debug("Product assigned Image from : #{path.inspect}")
-              rescue => e
-                puts "ERROR - Failed to assign attachment to #{owner.class} #{owner.id}"
-                logger.error("Failed to assign attachment to #{owner.class} #{owner.id}")
-              end
+
+              var_images << attachment if attachment
 
             end # images loop
+
+            # we have our variant images. Save them!
+            begin
+              # Link images to corresponding variant
+              variants[i].images << var_images
+              variants[i].save
+              logger.debug("Variant assigned Images from : #{var_images.inspect}")
+            rescue => e
+              puts "ERROR - Failed to assign attachments to #{variants[i].class} #{variants[i].id}"
+              logger.error("Failed to assign attachments to #{variants[i].class} #{variants[i].id}")
+            end
   
           end # variants_images_list loop
   
         # ... or just single Master Product?
         elsif(@load_object.variants.size == 0)
-          if(current_value.to_s.include?(Delimiters::multi_assoc_delim))
-            # count_on_hand column MUST HAVE "stock_location_name:master_count_on_hand" format
-            stock_location_name, master_count_on_hand = (current_value.to_s.split(Delimiters::multi_assoc_delim).first).split(Delimiters::name_value_delim)
-            puts "WARNING: Multiple count_on_hand values specified but no Variants/OptionTypes created"
-          else
-            stock_location_name, master_count_on_hand = current_value.split(Delimiters::name_value_delim)
-          end
-          if not stock_location_name # No Stock Location referenced, fallback to default one...
-            logger.info "No Stock Location was referenced. Adding count_on_hand to default Stock Location. Use 'stock_location_name:master_count_on_hand' format to specify prefered Stock Location"
-            stock_location = @@stock_location_klass.where(:default => true).first
-            raise "WARNING: Can't set count_on_hand as no Stock Location exists!" unless stock_location
-          else # go with the one specified...
-            stock_location = @@stock_location_klass.where(:name => stock_location_name).first
-            unless stock_location
-              stock_location = @@stock_location_klass.create( :name => stock_location_name)
-              logger.info "Created New Stock Location #{stock_location.inspect}"
+          
+            if(current_value.to_s.include?(Delimiters::multi_value_delim))
+              # multiple images
+              images = current_value.to_s.split(Delimiters::multi_value_delim)
+            else
+              # single image
+              images << variant_images 
             end
-          end
+  
+            logger.info "Setting #{images.count} images for Master variant #{@load_object.master.name}..."
 
-          if(stock_location)
-              @@stock_movement_klass.create(:quantity => master_count_on_hand.to_i, :stock_item => load_object.master.stock_items.find_by_stock_location_id(stock_location.id))
-              logger.info "Added #{master_count_on_hand} count_on_hand to Stock Location #{stock_location.inspect}"
-          else
-            puts "WARNING: Stock Location #{stock_location_name} NOT found - Can't set count_on_hand"
-          end
+            # Image processing...
+            images.each do |image|
+              @spree_uri_regexp ||= Regexp::new('(http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:\/~\+#]*[\w\-\@?^=%&amp;\/~\+#])?' )
+              
+              if(image.match(@spree_uri_regexp))
+                 
+                uri, attributes = image.split(Delimiters::attribute_list_start)
+                
+                uri.strip!
+                
+                logger.info("Processing IMAGE from URI [#{uri.inspect}]")
+      
+                if(attributes)
+                  #TODO move to ColumnPacker unpack ?
+                  attributes = attributes.split(', ').map{|h| h1,h2 = h.split('=>'); {h1.strip! => h2.strip!}}.reduce(:merge)
+                  logger.debug("IMAGE has additional attributes #{attributes.inspect}")
+                else
+                  attributes = {} # will blow things up later if we pass nil where {} expected
+                end
+                
+                agent = Mechanize.new
+                
+                image = begin
+                  agent.get(uri)
+                rescue => e
+                  puts "ERROR: Failed to fetch image from URL #{uri}", e.message
+                  raise DataShift::BadUri.new("Failed to fetch image from URL #{uri}")
+                end
+        
+                # Expected image is_a Mechanize::Image
+                # image.filename& image.extract_filename do not handle query string well e,g blah.jpg?v=1234
+                # so for now use URI
+                # extname = image.respond_to?(:filename) ? File.extname(image.filename) : File.extname(uri)
+                extname = File.extname( uri.gsub(/\?.*=.*/, ''))
+      
+                base = image.respond_to?(:filename) ? File.basename(image.filename, '.*') : File.basename(uri, '.*')
+      
+                logger.debug("Storing Image in TempFile #{base.inspect}.#{extname.inspect}")
+      
+                @current_image_temp_file = Tempfile.new([base, extname], :encoding => 'ascii-8bit')
+                          
+                begin
+        
+                  # TODO can we handle embedded img src e.g from Mechanize::Page::Image ?      
+      
+                  # If I call image.save(@current_image_temp_file.path) then it creates a new file with a .1 extension
+                  # so the real temp file data is empty and paperclip chokes
+                  # so this is a copy from the Mechanize::Image save method.  don't like it much, very brittle, but what to do ...
+                  until image.body_io.eof? do
+                    @current_image_temp_file.write image.body_io.read 16384
+                  end           
+                  
+                  @current_image_temp_file.rewind
+      
+                  logger.info("IMAGE downloaded from URI #{uri.inspect}")
+      
+                  attachment = create_attachment(Spree::Image, @current_image_temp_file.path, nil, nil, attributes)
+                  
+                rescue => e
+                  logger.error(e.message)
+                  logger.error("Failed to create Image from URL #{uri}")
+                  raise DataShift::DataProcessingError.new("Failed to create Image from URL #{uri}")
+             
+                ensure 
+                  @current_image_temp_file.close
+                  @current_image_temp_file.unlink
+                end
+      
+              else     
+                
+                path, alt_text = image.split(Delimiters::name_value_delim)
+
+                alt_text = @load_object.master.name if !alt_text #ensure alt_text is filled
+      
+                logger.debug("Processing IMAGE from PATH #{path.inspect} #{alt_text.inspect}")
+                
+                path = File.join(config[:image_path_prefix], path) if(config[:image_path_prefix])
+      
+                # create_attachment(klass, attachment_path, record = nil, attach_to_record_field = nil, options = {})
+                attachment = create_attachment(Spree::Image, path, nil, nil, :alt => alt_text)
+
+              end 
+
+              var_images << attachment if attachment
+
+            end # images loop
+
+            # we have our variant images. Save them!
+            begin
+              # Link images to corresponding variant
+              @load_object.master.images << var_images
+              @load_object.master.save
+              logger.debug("Master Variant assigned Images from : #{var_images.inspect}")
+            rescue => e
+              puts "ERROR - Failed to assign attachment to #{@load_object.master.class} #{@load_object.master.id}"
+              logger.error("Failed to assign attachment to #{@load_object.master.class} #{@load_object.master.id}")
+            end
+
         end        
       end
 

--- a/lib/loaders/spree/product_loader.rb
+++ b/lib/loaders/spree/product_loader.rb
@@ -296,7 +296,7 @@ module DataShift
               
               i = @load_object.variants.size + 1
 
-              variant = @load_object.variants.create( :sku => "#{load_object.sku}_#{i}", :price => load_object.price, :weight => load_object.weight, :height => load_object.height, :width => load_object.width, :depth => load_object.depth)
+              variant = @load_object.variants.create( :sku => "#{load_object.sku}_#{i}", :price => load_object.price, :weight => load_object.weight, :height => load_object.height, :width => load_object.width, :depth => load_object.depth, :tax_category_id => load_object.tax_category_id)
 
               variant.option_values << ov_list if(variant)    
             end

--- a/lib/loaders/spree/spree_base_loader.rb
+++ b/lib/loaders/spree/spree_base_loader.rb
@@ -77,7 +77,9 @@ module DataShift
       # different versions have moved images around from Prod to Variant
       owner = DataShift::SpreeEcom::get_image_owner(record)
 
-      get_each_assoc.each do |image|
+      #get_each_assoc.each do |image|
+      # multiple files should maintain comma separated logic with 'Delimiters::multi_value_delim' and not 'Delimiters::multi_assoc_delim'
+      @populator.current_value.to_s.split(Delimiters::multi_value_delim).each do |image|
 
         #TODO - make this Delimiters::attributes_start_delim and support {alt=> 'blah, :position => 2 etc}
 


### PR DESCRIPTION
1. We only had the possibility to load master variant images so I've added a new method to also be able to load variants images.
2. Added 'variant_cost_price' method as it wasn't present (variants can have different cost/final prices)
3. On existing method 'add_images' changed 'get_each_assoc' which expects a '|' to separate each image into @populator.current_value.to_s.split(Delimiters::multi_value_delim) in order to maintain multiple value logic (separated with a ','). I got confused when loading master variant images because it was expecting a '|'.