### PR TITLE
Fixes automatic model loading and logging exception in the shopify user ...

### DIFF
--- a/lib/thor/spree/shopify.thor
+++ b/lib/thor/spree/shopify.thor
@@ -30,9 +30,10 @@ module DatashiftSpree
       max_user = Alchemy::User.last.id
 
       begin
-        invoke 'datashift:import:csv', [], options.merge({model: Alchemy::User})
+        # We create the options hash in this weird way because options is a frozen hash
+        invoke 'datashift:import:csv', [], input: options[:input], model: Alchemy::User
       rescue => e
-        log :error, "Fcm Config was not validated. Please check log above, fix and rerun"
+        logger.error "Fcm Config was not validated. Please check log above, fix and rerun"
         exit(-1)
       end
 


### PR DESCRIPTION
...import

#### What's this PR do?
options is a Thor::CoreExt::HashWithIndifferentAccess which is a frozen hash. Therefore merge won't work and silently fails. The whole job then aborts since it is 'missing' the model param. The hacky workaround I put in place is likely the only thing that will work. In addition Thor doesn't have a log method so I switched it to logger.error to log out to the Rails log.