### PR TITLE
Sets order.shipment_state and cleans up shipments block

### DIFF
--- a/lib/loaders/spree/shopify_order_migrator.rb
+++ b/lib/loaders/spree/shopify_order_migrator.rb
@@ -303,13 +303,15 @@ module DataShift
 
         load_object.create_proposed_shipments
 
-        if(load_object.shipments.first)
-          load_object.shipments.first.state = 'shipped'
-          load_object.shipments.first.shipped_at = load_object.completed_at
+        # Spree::Order.shipments is a CollectionProxy (empty if no shipments)
+        # so each is safe to use
+        load_object.shipments.each do |s|
+          s.state = 'shipped'
+          s.shipped_at = load_object.completed_at
         end
 
-        load_object.payment_state = "paid"
-
+        load_object.payment_state = 'paid'
+        load_object.shipment_state = 'shipped'
         load_object.state = 'complete'
 
         logger.info("Order #{load_object.id}(#{load_object.number}) state set to 'complete' - Final Save")


### PR DESCRIPTION
#### What's this PR do?
This PR sets the order.shipment_state to shipped (since it is) and also cleans up the block that used to hackily check for shipments.first. Since Spree::Order.shipments is a CollectionsProxy which is just a fancy array a .each will operate equally well on an empty collection.